### PR TITLE
Drop chars in TextOutputDev with no unicode CMap

### DIFF
--- a/poppler/Gfx.cc
+++ b/poppler/Gfx.cc
@@ -3934,6 +3934,12 @@ void Gfx::doShowText(GooString *s) {
   int len, n, uLen, nChars, nSpaces, i;
 
   font = state->getFont();
+
+  if (out->needUnicodeText() && !font->hasToUnicodeCMap()) {
+    // No conversion to unicode available, drop characters.
+    return;
+  }
+
   wMode = font->getWMode();
 
   if (out->useDrawChar()) {

--- a/poppler/OutputDev.h
+++ b/poppler/OutputDev.h
@@ -116,6 +116,10 @@ public:
   // Does this device need non-text content?
   virtual GBool needNonText() { return gTrue; }
 
+  // Does this device expect valid UTF-8 text? (i.e, discard characters for
+  // which cannot determine UTF-8 equivalents due to a missing unicode mapping)
+  virtual GBool needUnicodeText() { return gFalse; }
+
   // Does this device require incCharCount to be called for text on
   // non-shown layers?
   virtual GBool needCharCount() { return gFalse; }

--- a/poppler/TextOutputDev.h
+++ b/poppler/TextOutputDev.h
@@ -762,6 +762,10 @@ public:
   // Does this device need non-text content?
   virtual GBool needNonText() { return gFalse; }
 
+  // Does this device expect valid UTF-8 text? (i.e, discard characters for
+  // which cannot determine UTF-8 equivalents due to a missing unicode mapping)
+  virtual GBool needUnicodeText() { return gTrue; }
+
   // Does this device require incCharCount to be called for text on
   // non-shown layers?
   virtual GBool needCharCount() { return gTrue; }


### PR DESCRIPTION
If the font has no unicode cmap, it's not possible to output text for
that encoding, so rather than potentially corrupting the textual output
stream, the characters are dropped.

It may be possible to keep the characters if they happen to lie in the
printable spectrum, but my first priority is to fix crashes where the
glib API returns an inconsistent number of glyphs via
poppler_page_get_text and poppler_page_get_text_layout.

Bug: https://bugs.freedesktop.org/show_bug.cgi?id=73885
