### PR TITLE
Add dump glyphs utility

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -107,6 +107,13 @@ target_link_libraries(pdftotext ${common_libs})
 install(TARGETS pdftotext DESTINATION bin)
 install(FILES pdftotext.1 DESTINATION share/man/man1)
 
+# dumpglyphs
+set(dumpglyphs_SOURCES ${common_srcs}
+  dumpglyphs.cc
+)
+add_executable(dumpglyphs ${dumpglyphs_SOURCES})
+target_link_libraries(dumpglyphs ${common_libs})
+
 # pdftohtml
 set(pdftohtml_SOURCES ${common_srcs}
   pdftohtml.cc

--- a/utils/dumpglyphs.cc
+++ b/utils/dumpglyphs.cc
@@ -1,0 +1,260 @@
+//========================================================================
+//
+// pdftotext.cc
+//
+// Copyright 1997-2003 Glyph & Cog, LLC
+//
+// Modified for Debian by Hamish Moffatt, 22 May 2002.
+//
+//========================================================================
+
+//========================================================================
+//
+// Modified under the Poppler project - http://poppler.freedesktop.org
+//
+// All changes made under the Poppler project to this file are licensed
+// under GPL version 2 or later
+//
+// Copyright (C) 2006 Dominic Lachowicz <cinamod@hotmail.com>
+// Copyright (C) 2007-2008, 2010, 2011 Albert Astals Cid <aacid@kde.org>
+// Copyright (C) 2009 Jan Jockusch <jan@jockusch.de>
+// Copyright (C) 2010, 2013 Hib Eris <hib@hiberis.nl>
+// Copyright (C) 2010 Kenneth Berland <ken@hero.com>
+// Copyright (C) 2011 Tom Gleason <tom@buildadam.com>
+// Copyright (C) 2011 Steven Murdoch <Steven.Murdoch@cl.cam.ac.uk>
+// Copyright (C) 2013 Yury G. Kudryashov <urkud.urkud@gmail.com>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
+//
+// To see a description of the changes please see the Changelog file that
+// came with your tarball or type make ChangeLog if you are building from git
+//
+//========================================================================
+
+#include "config.h"
+#include <poppler-config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include "parseargs.h"
+#include "goo/GooString.h"
+#include "goo/gmem.h"
+#include "GlobalParams.h"
+#include "Object.h"
+#include "Stream.h"
+#include "Array.h"
+#include "Dict.h"
+#include "XRef.h"
+#include "Catalog.h"
+#include "Page.h"
+#include "PDFDoc.h"
+#include "PDFDocFactory.h"
+#include "TextOutputDev.h"
+#include "CharTypes.h"
+#include "UnicodeMap.h"
+#include "PDFDocEncoding.h"
+#include "Error.h"
+#include <string>
+
+static int firstPage = 1;
+static int lastPage = 0;
+static double resolution = 72.0;
+static int x = 0;
+static int y = 0;
+static int w = 0;
+static int h = 0;
+static char ownerPassword[33] = "\001";
+static char userPassword[33] = "\001";
+static GBool quiet = gFalse;
+static GBool printVersion = gFalse;
+static GBool printHelp = gFalse;
+
+static const ArgDesc argDesc[] = {
+  {"-f",       argInt,      &firstPage,     0,
+   "first page to convert"},
+  {"-l",       argInt,      &lastPage,      0,
+   "last page to convert"},
+  {"-r",      argFP,       &resolution,    0,
+   "resolution, in DPI (default is 72)"},
+  {"-x",      argInt,      &x,             0,
+   "x-coordinate of the crop area top left corner"},
+  {"-y",      argInt,      &y,             0,
+   "y-coordinate of the crop area top left corner"},
+  {"-W",      argInt,      &w,             0,
+   "width of crop area in pixels (default is 0)"},
+  {"-H",      argInt,      &h,             0,
+   "height of crop area in pixels (default is 0)"},
+  {"-opw",     argString,   ownerPassword,  sizeof(ownerPassword),
+   "owner password (for encrypted files)"},
+  {"-upw",     argString,   userPassword,   sizeof(userPassword),
+   "user password (for encrypted files)"},
+  {"-q",       argFlag,     &quiet,         0,
+   "don't print any messages or errors"},
+  {"-v",       argFlag,     &printVersion,  0,
+   "print copyright and version info"},
+  {"-h",       argFlag,     &printHelp,     0,
+   "print usage information"},
+  {"-help",    argFlag,     &printHelp,     0,
+   "print usage information"},
+  {"--help",   argFlag,     &printHelp,     0,
+   "print usage information"},
+  {"-?",       argFlag,     &printHelp,     0,
+   "print usage information"},
+  {NULL}
+};
+
+class DumpGlyphsDev: public OutputDev {
+public:
+  DumpGlyphsDev() {}
+
+  virtual GBool interpretType3Chars() { return gFalse; }
+  virtual GBool upsideDown() { return gFalse; }
+  virtual GBool useDrawChar() { return gTrue; }
+
+  virtual void drawChar(GfxState *state, double x, double y,
+      double dx, double dy,
+      double originX, double originY,
+      CharCode c, int nBytes, Unicode *u, int uLen) {
+    printf("%f\x1f%f\x1f%f\x1f%f\x1f%f\x1f%f\x1f%c\x1f%d\x1f%d\x1f%d\x1e", x, y, dx, dy, originX, originY, c, nBytes, *u, uLen);
+  }
+};
+
+int main(int argc, char *argv[]) {
+  PDFDoc *doc;
+  GooString *fileName;
+  GooString *textFileName;
+  GooString *ownerPW, *userPW;
+  UnicodeMap *uMap;
+  Object info;
+  GBool ok;
+  char *p;
+  int exitCode;
+
+  exitCode = 99;
+
+  // parse args
+  ok = parseArgs(argDesc, &argc, argv);
+  if (!ok || (argc < 2) || argc > 3 || printVersion || printHelp) {
+    fprintf(stderr, "dumpglyphs version %s\n", PACKAGE_VERSION);
+    fprintf(stderr, "%s\n", popplerCopyright);
+    fprintf(stderr, "%s\n", xpdfCopyright);
+    if (!printVersion) {
+      printUsage("dumpglyphs", "<PDF-file>", argDesc);
+    }
+    if (printVersion || printHelp)
+      exitCode = 0;
+    goto err0;
+  }
+
+  // read config file
+  globalParams = new GlobalParams();
+
+  fileName = new GooString(argv[1]);
+  
+  if (quiet) {
+    globalParams->setErrQuiet(quiet);
+  }
+
+  // get mapping to output encoding
+  if (!(uMap = globalParams->getTextEncoding())) {
+    error(errCommandLine, -1, "Couldn't get text encoding");
+    delete fileName;
+    goto err1;
+  }
+
+  // open PDF file
+  if (ownerPassword[0] != '\001') {
+    ownerPW = new GooString(ownerPassword);
+  } else {
+    ownerPW = NULL;
+  }
+  if (userPassword[0] != '\001') {
+    userPW = new GooString(userPassword);
+  } else {
+    userPW = NULL;
+  }
+
+  if (fileName->cmp("-") == 0) {
+      delete fileName;
+      fileName = new GooString("fd://0");
+  }
+
+  doc = PDFDocFactory().createPDFDoc(*fileName, ownerPW, userPW);
+
+  if (userPW) {
+    delete userPW;
+  }
+  if (ownerPW) {
+    delete ownerPW;
+  }
+  if (!doc->isOk()) {
+    exitCode = 1;
+    goto err2;
+  }
+
+#ifdef ENFORCE_PERMISSIONS
+  // check for copy permission
+  if (!doc->okToCopy()) {
+    error(errNotAllowed, -1, "Copying of text from this document is not allowed.");
+    exitCode = 3;
+    goto err2;
+  }
+#endif
+
+  // construct text file name
+  if (argc == 3) {
+    textFileName = new GooString(argv[2]);
+  } else if (fileName->cmp("fd://0") == 0) {
+     error(errCommandLine, -1, "You have to provide an output filename when reading form stdin.");
+     goto err2;
+  } else {
+    p = fileName->getCString() + fileName->getLength() - 4;
+    if (!strcmp(p, ".pdf") || !strcmp(p, ".PDF")) {
+      textFileName = new GooString(fileName->getCString(),
+				 fileName->getLength() - 4);
+    } else {
+      textFileName = fileName->copy();
+    }
+  }
+
+  // get page range
+  if (firstPage < 1) {
+    firstPage = 1;
+  }
+  if (lastPage < 1 || lastPage > doc->getNumPages()) {
+    lastPage = doc->getNumPages();
+  }
+  if (lastPage < firstPage) {
+    error(errCommandLine, -1,
+          "Wrong page range given: the first page ({0:d}) can not be after the last page ({1:d}).",
+          firstPage, lastPage);
+    goto err3;
+  }
+
+{
+  DumpGlyphsDev *textOut = new DumpGlyphsDev();
+  for (int page = firstPage; page <= lastPage; ++page) {
+    printf("\x1d");
+    doc->displayPage(textOut, page, resolution, resolution, 0, gTrue, gFalse, gFalse);
+  }
+}
+
+  exitCode = 0;
+
+  // clean up
+ err3:
+  delete textFileName;
+ err2:
+  delete doc;
+  delete fileName;
+  uMap->decRefCnt();
+ err1:
+  delete globalParams;
+ err0:
+
+  // check for memory leaks
+  Object::memCheck(stderr);
+  gMemReport(stderr);
+
+  return exitCode;
+}


### PR DESCRIPTION
# This pull request is not intended to be merged.

This code is used to inspect what information is being fed into `drawChars`, to see if the `TextOutputDev` is doing anything special.

The output looks something like this:
- an X and Y coordinate is provided
- a DX and DY are provided, but are simply functions of the previous X and Y, and not a width/height.
- the origin always seems to be zero

The tricky part seems to be taking this coordinate and turning it into a bounding box, which is performed by the TextOutputDev only as it constructs words, as far as I can tell.

```
540.672984, 522.000000, 3.589560, 0.000000, 0.000000, 0.000000, 53, 1, 53, 1
544.262544, 522.000000, 3.589560, 0.000000, 0.000000, 0.000000, 51, 1, 51, 1
547.852104, 522.000000, 3.589560, 0.000000, 0.000000, 0.000000, 49, 1, 49, 1
551.441664, 522.000000, 1.770000, 0.000000, 0.000000, 0.000000, 44, 1, 44, 1
553.211664, 522.000000, 3.589560, 0.000000, 0.000000, 0.000000, 51, 1, 51, 1
556.801224, 522.000000, 3.589560, 0.000000, 0.000000, 0.000000, 55, 1, 55, 1
560.390784, 522.000000, 3.589560, 0.000000, 0.000000, 0.000000, 51, 1, 51, 1
141.240000, 514.440100, 3.504600, 0.000000, 0.000000, 0.000000, 84, 1, 84, 1
```
